### PR TITLE
Add reusable word splitting function with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # word-splitter
+
+## Running Tests
+
+Ensure you have Node.js installed, then execute:
+
+```bash
+node test.js
+```
+
+This runs a series of assertions against the `calculateParts` function.

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
             <input type="text" id="wordInput" placeholder="Enter a word">
         </div>
     </div>
+    <script src="splitter.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,28 +1,6 @@
 function splitWord() {
     const word = document.getElementById("wordInput").value;
-    const length = word.length;
-
-    if (length === 0) {
-        // Clear results if no input
-        document.getElementById("part1").textContent = '';
-        document.getElementById("part2").textContent = '';
-        document.getElementById("part3").textContent = '';
-        return;
-    }
-
-    // Calculate part lengths
-    const minLength = Math.floor(length / 3);
-    const remainder = length % 3;
-
-    // Adjust part lengths to ensure part1 and part3 have the same number of letters
-    let part1Length = minLength + (remainder > 0 ? 1 : 0);
-    let part3Length = minLength + (remainder > 1 ? 1 : 0);
-    let part2Length = length - (part1Length + part3Length);
-
-    // Extract parts based on calculated lengths
-    const part1 = word.slice(0, part1Length);
-    const part2 = word.slice(part1Length, part1Length + part2Length);
-    const part3 = word.slice(part1Length + part2Length);
+    const { part1, part2, part3 } = calculateParts(word);
 
     document.getElementById("part1").textContent = part1;
     document.getElementById("part2").textContent = part2;

--- a/splitter.js
+++ b/splitter.js
@@ -1,0 +1,25 @@
+function calculateParts(word) {
+    const length = word.length;
+    if (length === 0) {
+        return { part1: '', part2: '', part3: '' };
+    }
+
+    const minLength = Math.floor(length / 3);
+    const remainder = length % 3;
+
+    let part1Length = minLength + (remainder > 0 ? 1 : 0);
+    let part3Length = minLength + (remainder > 1 ? 1 : 0);
+    let part2Length = length - (part1Length + part3Length);
+
+    const part1 = word.slice(0, part1Length);
+    const part2 = word.slice(part1Length, part1Length + part2Length);
+    const part3 = word.slice(part1Length + part2Length);
+
+    return { part1, part2, part3 };
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = calculateParts;
+} else if (typeof window !== 'undefined') {
+    window.calculateParts = calculateParts;
+}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,19 @@
+const assert = require('assert');
+const calculateParts = require('./splitter');
+
+const tests = [
+  { word: '', expected: { part1: '', part2: '', part3: '' } },
+  { word: 'a', expected: { part1: 'a', part2: '', part3: '' } },
+  { word: 'ab', expected: { part1: 'a', part2: '', part3: 'b' } },
+  { word: 'abc', expected: { part1: 'a', part2: 'b', part3: 'c' } },
+  { word: 'abcd', expected: { part1: 'ab', part2: 'c', part3: 'd' } },
+  { word: 'abcde', expected: { part1: 'ab', part2: 'c', part3: 'de' } },
+  { word: 'abcdef', expected: { part1: 'ab', part2: 'cd', part3: 'ef' } }
+];
+
+for (const { word, expected } of tests) {
+  const result = calculateParts(word);
+  assert.deepStrictEqual(result, expected, `Failed on word: ${word}`);
+}
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- move splitting logic to new `calculateParts` function
- load new module from the HTML page and refactor `splitWord`
- provide a Node.js test script for `calculateParts`
- describe running tests in README

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_683f85c8425883288389cbac6dc4391d