### PR TITLE
Add Laravel backend skeleton with Sanctum

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# word-splitter
+# Word Splitter
+
+This project demonstrates splitting words into three parts with a simple front-end.
+A Laravel 12 backend (found in `backend/`) exposes API endpoints secured with
+Sanctum for SPA authentication.
+
+## Backend Setup
+
+The backend directory contains a minimal Laravel skeleton with migrations and
+controllers for authentication and word splitting. Install dependencies and run
+migrations:
+
+```bash
+cd backend
+composer install
+php artisan migrate
+```
+
+## API
+
+- `POST /api/register` – create a new user
+- `POST /api/login` – login the user
+- `POST /api/logout` – logout
+- `GET  /api/user` – fetch the current user
+- `POST /api/split-word` – split a word and store the result
+- `GET  /api/split-history` – list previous splits
+
+The front-end fetches CSRF cookies and sends authenticated requests with the
+appropriate headers.

--- a/backend/app/Http/Controllers/AuthController.php
+++ b/backend/app/Http/Controllers/AuthController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Auth;
+
+class AuthController extends Controller
+{
+    public function register(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string',
+            'email' => 'required|email|unique:users,email',
+            'password' => 'required|min:6',
+        ]);
+
+        $user = User::create([
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'password' => Hash::make($data['password']),
+        ]);
+
+        return response()->json($user, 201);
+    }
+
+    public function login(Request $request)
+    {
+        $credentials = $request->validate([
+            'email' => 'required|email',
+            'password' => 'required',
+        ]);
+
+        if (!Auth::attempt($credentials)) {
+            return response()->json(['message' => 'Invalid credentials'], 401);
+        }
+
+        $request->session()->regenerate();
+
+        return response()->json(['message' => 'Logged in']);
+    }
+
+    public function logout(Request $request)
+    {
+        Auth::guard('web')->logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+        return response()->json(['message' => 'Logged out']);
+    }
+}

--- a/backend/app/Http/Controllers/UserController.php
+++ b/backend/app/Http/Controllers/UserController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class UserController extends Controller
+{
+    public function current(Request $request)
+    {
+        return response()->json($request->user());
+    }
+}

--- a/backend/app/Http/Controllers/WordSplitController.php
+++ b/backend/app/Http/Controllers/WordSplitController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\WordSplit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class WordSplitController extends Controller
+{
+    public function split(Request $request)
+    {
+        $data = $request->validate([
+            'word' => 'required|string',
+        ]);
+
+        $word = $data['word'];
+        $length = strlen($word);
+        $min = intdiv($length, 3);
+        $remainder = $length % 3;
+
+        $part1Len = $min + ($remainder > 0 ? 1 : 0);
+        $part3Len = $min + ($remainder > 1 ? 1 : 0);
+        $part2Len = $length - ($part1Len + $part3Len);
+
+        $parts = [
+            'part1' => substr($word, 0, $part1Len),
+            'part2' => substr($word, $part1Len, $part2Len),
+            'part3' => substr($word, $part1Len + $part2Len),
+        ];
+
+        $split = WordSplit::create([
+            'user_id' => $request->user()->id,
+            'word' => $word,
+            'part1' => $parts['part1'],
+            'part2' => $parts['part2'],
+            'part3' => $parts['part3'],
+        ]);
+
+        return response()->json($split);
+    }
+
+    public function history(Request $request)
+    {
+        return response()->json(
+            WordSplit::where('user_id', $request->user()->id)->latest()->get()
+        );
+    }
+}

--- a/backend/app/Http/Kernel.php
+++ b/backend/app/Http/Kernel.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http;
+
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+
+class Kernel extends HttpKernel
+{
+    protected $middleware = [
+        // Global middleware
+    ];
+
+    protected $middlewareGroups = [
+        'web' => [
+            \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+            \App\Http\Middleware\VerifyCsrfToken::class,
+        ],
+        'api' => [
+            'throttle:api',
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ],
+    ];
+}

--- a/backend/app/Http/Middleware/VerifyCsrfToken.php
+++ b/backend/app/Http/Middleware/VerifyCsrfToken.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as Middleware;
+
+class VerifyCsrfToken extends Middleware
+{
+    protected $addHttpCookie = true;
+
+    protected $except = [
+        //
+    ];
+}

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
+
+class User extends Authenticatable
+{
+    use HasApiTokens, HasFactory, Notifiable;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+}

--- a/backend/app/Models/WordSplit.php
+++ b/backend/app/Models/WordSplit.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class WordSplit extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'word',
+        'part1',
+        'part2',
+        'part3',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "word-splitter/backend",
+    "type": "project",
+    "require": {
+        "php": "^8.2",
+        "laravel/framework": "^12.0",
+        "laravel/sanctum": "^4.0"
+    }
+}

--- a/backend/config/sanctum.php
+++ b/backend/config/sanctum.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', 'localhost')),
+    'guard' => ['web'],
+    'expiration' => null,
+    'middleware' => [
+        'verify_csrf_token' => App\Http\Middleware\VerifyCsrfToken::class,
+        'encrypt_cookies' => Illuminate\Cookie\Middleware\EncryptCookies::class,
+    ],
+];

--- a/backend/database/migrations/2024_01_01_000000_create_users_table.php
+++ b/backend/database/migrations/2024_01_01_000000_create_users_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('users');
+    }
+};

--- a/backend/database/migrations/2024_01_01_000001_create_word_splits_table.php
+++ b/backend/database/migrations/2024_01_01_000001_create_word_splits_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('word_splits', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('word');
+            $table->string('part1');
+            $table->string('part2')->nullable();
+            $table->string('part3');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('word_splits');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AuthController;
+use App\Http\Controllers\UserController;
+use App\Http\Controllers\WordSplitController;
+
+Route::middleware('web')->group(function () {
+    Route::post('/register', [AuthController::class, 'register']);
+    Route::post('/login', [AuthController::class, 'login']);
+    Route::post('/logout', [AuthController::class, 'logout']);
+    Route::get('/user', [UserController::class, 'current']);
+    Route::post('/split-word', [WordSplitController::class, 'split']);
+    Route::get('/split-history', [WordSplitController::class, 'history']);
+});

--- a/script.js
+++ b/script.js
@@ -1,32 +1,42 @@
-function splitWord() {
-    const word = document.getElementById("wordInput").value;
-    const length = word.length;
+const API_BASE = '/backend/public';
 
-    if (length === 0) {
-        // Clear results if no input
-        document.getElementById("part1").textContent = '';
-        document.getElementById("part2").textContent = '';
-        document.getElementById("part3").textContent = '';
+async function getCsrfCookie() {
+    await fetch(`${API_BASE}/sanctum/csrf-cookie`, {
+        credentials: 'include'
+    });
+}
+
+async function splitWord() {
+    const word = document.getElementById('wordInput').value;
+    if (!word) {
+        document.getElementById('part1').textContent = '';
+        document.getElementById('part2').textContent = '';
+        document.getElementById('part3').textContent = '';
         return;
     }
 
-    // Calculate part lengths
-    const minLength = Math.floor(length / 3);
-    const remainder = length % 3;
+    await getCsrfCookie();
 
-    // Adjust part lengths to ensure part1 and part3 have the same number of letters
-    let part1Length = minLength + (remainder > 0 ? 1 : 0);
-    let part3Length = minLength + (remainder > 1 ? 1 : 0);
-    let part2Length = length - (part1Length + part3Length);
+    const response = await fetch(`${API_BASE}/api/split-word`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest'
+        },
+        body: JSON.stringify({ word })
+    });
 
-    // Extract parts based on calculated lengths
-    const part1 = word.slice(0, part1Length);
-    const part2 = word.slice(part1Length, part1Length + part2Length);
-    const part3 = word.slice(part1Length + part2Length);
+    if (!response.ok) {
+        console.error('Split failed');
+        return;
+    }
 
-    document.getElementById("part1").textContent = part1;
-    document.getElementById("part2").textContent = part2;
-    document.getElementById("part3").textContent = part3;
+    const data = await response.json();
+    document.getElementById('part1').textContent = data.part1;
+    document.getElementById('part2').textContent = data.part2;
+    document.getElementById('part3').textContent = data.part3;
 }
 
 function drawCurve() {
@@ -72,3 +82,67 @@ document.getElementById('wordInput').addEventListener('keypress', function(event
         splitWord(); // Call splitWord function on Enter key press
     }
 });
+
+async function register(name, email, password) {
+    await getCsrfCookie();
+    return fetch(`${API_BASE}/api/register`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest'
+        },
+        body: JSON.stringify({ name, email, password })
+    });
+}
+
+async function login(email, password) {
+    await getCsrfCookie();
+    return fetch(`${API_BASE}/api/login`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest'
+        },
+        body: JSON.stringify({ email, password })
+    });
+}
+
+async function logout() {
+    await getCsrfCookie();
+    return fetch(`${API_BASE}/api/logout`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+            'Accept': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest'
+        }
+    });
+}
+
+async function currentUser() {
+    await getCsrfCookie();
+    const res = await fetch(`${API_BASE}/api/user`, {
+        credentials: 'include',
+        headers: {
+            'Accept': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest'
+        }
+    });
+    return res.json();
+}
+
+async function splitHistory() {
+    await getCsrfCookie();
+    const res = await fetch(`${API_BASE}/api/split-history`, {
+        credentials: 'include',
+        headers: {
+            'Accept': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest'
+        }
+    });
+    return res.json();
+}


### PR DESCRIPTION
## Summary
- initialize a Laravel 12 skeleton in `backend/` with Sanctum and CSRF middleware
- implement `User` and `WordSplit` models plus migrations
- create controllers and routes for auth and word splitting
- update front-end JS to call new API endpoints using required headers
- document backend setup and API usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840c86461f48328bf7e06dc613305c3